### PR TITLE
Port to 1.21.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // see https://fabricmc.net/develop/ for new versions
-    id 'fabric-loom' version '1.7-SNAPSHOT' apply false
+    id 'fabric-loom' version '1.9-SNAPSHOT' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
-    id 'net.neoforged.moddev' version '1.0.14' apply false
+    id 'net.neoforged.moddev' version '1.0.21' apply false
 }

--- a/common/src/main/java/com/diontryban/flourish/mixin/FlowerBlockMixin.java
+++ b/common/src/main/java/com/diontryban/flourish/mixin/FlowerBlockMixin.java
@@ -105,7 +105,7 @@ public abstract class FlowerBlockMixin extends BushBlock implements Bonemealable
             pData *= 3;
             d1 = 1.0D;
             d0 = 3.0D;
-        } else if (blockstate.isSolidRender(pLevel, pPos)) {
+        } else if (blockstate.isSolidRender()) {
             pPos = pPos.above();
             pData *= 3;
             d0 = 3.0D;

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Every field you add must be added to the multiloader-common build.gradle expandProps map.
 
 # Project
-version=21.0.0
+version=21.4.0
 group=com.diontryban.flourish
 java_version=21
 
@@ -13,22 +13,22 @@ mod_id=flourish
 license=LGPL-3.0-or-later
 credits=
 description=Spread small flowers with bonemeal.
-minecraft_version=1.21
+minecraft_version=1.21.4
 minecraft_version_range=[1.21, 1.22)
 # https://projects.neoforged.net/neoforged/neoform
-neo_form_version=1.21-20240613.152323
+neo_form_version=1.21.4-20241203.161809
 # https://parchmentmc.org/docs/getting-started#choose-a-version
-parchment_minecraft=1.21
-parchment_version=2024.07.07
+parchment_minecraft=1.21.4
+parchment_version=2024.12.07
 ash_version=21.0.1-beta
 
 # Fabric
-fabric_version=0.100.7+1.21
-fabric_loader_version=0.15.11
-modmenu_version=11.0.0
+fabric_version=0.112.2+1.21.4
+fabric_loader_version=0.16.9
+modmenu_version=13.0.0-beta.1
 
 # NeoForge
-neoforge_version=21.0.114-beta
+neoforge_version=21.4.38-beta
 neoforge_loader_version_range=[4,)
 
 # Gradle

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -29,10 +29,6 @@ neoForge {
             client()
         }
 
-        data {
-            data()
-        }
-
         server {
             server()
         }


### PR DESCRIPTION
Very minor changes, mostly a version bump. Had to disable Neo data-gen temporarily, as its been split into client + server, but existing data seems to work for now. The 1.21 version of Ash API works on 1.21.4. 